### PR TITLE
Fix New Task and Edit Task Forms

### DIFF
--- a/documents/melvinacademia.md
+++ b/documents/melvinacademia.md
@@ -28,3 +28,5 @@
  2. Removed isAppointment toggle from form and removed Appointment attribute from task view
  3. Added isComplete toggle, can save completed and incompleted statuses, previous form had isComplete hard coded to false
  4. Implemented autosave functionality on Taskform and removed save button, form now calls update mutation each time a field is changed, so each input is automatically saved.
+ 5. Editing task is supposed to autosave and have no save button and creating a task needs a save button and only saves when submitted. This is causes issues because our pages for editing a task and creating a new task rely on the same form. This is fixed by creating two separate components for each of these functionalities. The component Taskform is used for editing and has autosave, and is used on the edit task page.  TaskFormNew is used for creating tasks and only saves when submitted and is used on the new task page, that way the pages aren't trying to use the same form for two different things
+ 6. fixed a bug where trying to create a task that is marked completed would cause an error.

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "cross-undici-fetch": "^0.4.14",
     "dotenv": "^16.0.3",
     "googleapis": "^109.0.1",
+    "moment": "^2.29.4",
     "moments": "^0.0.2",
     "react-datetime": "^3.2.0",
     "react-icons": "^4.6.0",

--- a/web/src/components/Task/NewTask/NewTask.js
+++ b/web/src/components/Task/NewTask/NewTask.js
@@ -4,7 +4,7 @@ import { navigate, routes } from '@redwoodjs/router'
 import { useMutation } from '@redwoodjs/web'
 import { toast } from '@redwoodjs/web/toast'
 
-import TaskForm from 'src/components/Task/TaskForm'
+import TaskFormNew from '../TaskFormNew/TaskFormNew'
 
 const CREATE_TASK_MUTATION = gql`
   mutation CreateTaskMutation($input: CreateTaskInput!) {
@@ -40,7 +40,7 @@ const NewTask = () => {
         </Center>
       </header>
       <div className="rw-segment-main">
-        <TaskForm onSave={onSave} loading={loading} error={error} />
+        <TaskFormNew onSave={onSave} loading={loading} error={error} />
       </div>
     </div>
   )

--- a/web/src/components/Task/TaskFormNew/TaskFormNew.js
+++ b/web/src/components/Task/TaskFormNew/TaskFormNew.js
@@ -1,5 +1,3 @@
-import { useEffect, useState } from 'react'
-
 import {
   Box,
   SimpleGrid,
@@ -8,7 +6,6 @@ import {
   ButtonGroup,
   Center,
 } from '@chakra-ui/react'
-import moment from 'moment'
 
 import { useAuth } from '@redwoodjs/auth'
 import {
@@ -24,25 +21,6 @@ import {
   DateField,
   InputField,
 } from '@redwoodjs/forms'
-import { MetaTags, useMutation } from '@redwoodjs/web'
-
-import { checkboxInputTag, timeTag } from 'src/lib/formatters'
-const UPDATE_TASK = gql`
-  mutation updateTaskMutation($id: Int!, $input: UpdateTaskInput!) {
-    updateTask(id: $id, input: $input) {
-      id
-      userID
-      isAppointment
-      title
-      description
-      duration
-      priority
-      completed
-      dueDate
-      createdAt
-    }
-  }
-`
 const TaskForm = (props) => {
   const { isAuthenticated, currentUser } = useAuth()
   console.log(isAuthenticated)
@@ -50,69 +28,12 @@ const TaskForm = (props) => {
   const onSubmit = (data) => {
     data.userID = currentUser.id
     data.isAppointment = false
-    props.onSave(data, props?.task?.id)
-  }
-  const [titleChange, setTitleChange] = useState(false)
-  const [create] = useMutation(UPDATE_TASK)
-  const titleHandler = (e) => {
-    create({
-      variables: {
-        id: parseInt(props?.task?.id),
-        input: { title: e.target.value },
-      },
-    })
-  }
-  const [descChange, setDescChange] = useState(false)
-  const descHandler = (e) => {
-    create({
-      variables: {
-        id: parseInt(props?.task?.id),
-        input: { description: e.target.value },
-      },
-    })
-  }
-  const [durChange, setDurChange] = useState(false)
-  const durHandler = (e) => {
-    create({
-      variables: {
-        id: parseInt(props?.task?.id),
-        input: { duration: parseInt(e.target.value) },
-      },
-    })
-  }
-  const [priChange, setPriChange] = useState(false)
-  const priHandler = (e) => {
-    create({
-      variables: {
-        id: parseInt(props?.task?.id),
-        input: { duration: parseInt(e.target.value) },
-      },
-    })
-  }
-  const completeHandler = (e) => {
-    var setComplete = false
     if (document.getElementById('completed').checked) {
-      setComplete = true
+      data.completed = true
     } else {
-      setComplete = false
+      data.completed = false
     }
-    create({
-      variables: {
-        id: parseInt(props?.task?.id),
-        input: { completed: setComplete },
-      },
-    })
-  }
-  const dateHandler = (e) => {
-    var dateSet = Date.parse(e.target.value)
-    create({
-      variables: {
-        id: parseInt(props?.task?.id),
-        input: {
-          dueDate: moment(dateSet).format('YYYY-MM-DDTHH:mm:ss.SSSZ'),
-        },
-      },
-    })
+    props.onSave(data, props?.task?.id)
   }
 
   return (
@@ -142,9 +63,6 @@ const TaskForm = (props) => {
                   className="rw-input"
                   errorClassName="rw-input rw-input-error"
                   validation={{ required: true }}
-                  onChange={(e) => {
-                    titleHandler(e)
-                  }}
                 />
               </Box>
               <Box w="100%" bg="white" color="blue.500">
@@ -164,9 +82,6 @@ const TaskForm = (props) => {
                   className="rw-input"
                   errorClassName="rw-input rw-input-error"
                   validation={{ required: true }}
-                  onChange={(e) => {
-                    descHandler(e)
-                  }}
                 />
               </Box>
 
@@ -187,7 +102,6 @@ const TaskForm = (props) => {
                   className="rw-input"
                   errorClassName="rw-input rw-input-error"
                   validation={{ required: true }}
-                  nChange={durHandler}
                 />
               </Box>
 
@@ -208,7 +122,6 @@ const TaskForm = (props) => {
                   className="rw-input"
                   errorClassName="rw-input rw-input-error"
                   validation={{ required: true }}
-                  onChange={priHandler}
                 />
               </Box>
               <Box w="100%" bg="white" color="blue.500">
@@ -222,7 +135,7 @@ const TaskForm = (props) => {
                 </Label>
               </Box>
               <Box w="100%" bg="white" color="blue.500">
-                <DateField name="dueDate" onChange={dateHandler} />
+                <DateField name="dueDate" />
                 <FieldError name="dueDate" className="rw-field-error" />
               </Box>
               <Box w="100%" bg="white" color="blue.500">
@@ -234,7 +147,6 @@ const TaskForm = (props) => {
                   <Text as="b">Task Completed?</Text>
                 </Label>
               </Box>
-
               <Box w="100%" bg="white" color="blue.500">
                 <CheckboxField
                   name="completed"
@@ -242,8 +154,20 @@ const TaskForm = (props) => {
                   className="rw-input"
                   errorClassName="rw-input rw-input-error"
                   validation={{ required: false }}
-                  onChange={completeHandler}
                 />
+              </Box>
+
+              <Box w="100%" bg="white" color="blue.500">
+                <Button colorScheme="gray" variant="outline" size="md">
+                  <div className="rw-button-group">
+                    <Submit
+                      disabled={props.loading}
+                      className="rw-button rw-button-blue"
+                    >
+                      Save
+                    </Submit>
+                  </div>
+                </Button>
               </Box>
             </SimpleGrid>
           </Form>

--- a/web/src/components/Task/TaskFormNew/TaskFormNew.stories.js
+++ b/web/src/components/Task/TaskFormNew/TaskFormNew.stories.js
@@ -1,0 +1,7 @@
+import TaskFormNew from './TaskFormNew'
+
+export const generated = () => {
+  return <TaskFormNew taskformnew={{}} />
+}
+
+export default { title: 'Components/TaskFormNew' }

--- a/yarn.lock
+++ b/yarn.lock
@@ -24008,7 +24008,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"moment@npm:^2.10.6":
+"moment@npm:^2.10.6, moment@npm:^2.29.4":
   version: 2.29.4
   resolution: "moment@npm:2.29.4"
   checksum: 844c6f3ce42862ac9467c8ca4f5e48a00750078682cc5bda1bc0e50cc7ca88e2115a0f932d65a06e4a90e26cb78892be9b3ca3dd6546ca2c4d994cebb787fc2b
@@ -29077,6 +29077,7 @@ __metadata:
     cross-undici-fetch: ^0.4.14
     dotenv: ^16.0.3
     googleapis: ^109.0.1
+    moment: ^2.29.4
     moments: ^0.0.2
     react-datetime: ^3.2.0
     react-icons: ^4.6.0


### PR DESCRIPTION
Editing a task is supposed to autosave and have no save button while creating a task needs a save button and only saves when submitted. This is causes issues because our pages for editing a task and creating a new task rely on the same form. This is fixed by creating two separate components for each of these functionalities. The component Taskform is used for editing and has autosave, and is used on the edit task page.  TaskFormNew is used for creating tasks and only saves when submitted and is used on the new task page, that way the pages aren't trying to use the same form for two different things

Also, fixed a bug where trying to create a task that is marked completed would cause an error.

Autosave requires the use of momentjs functions, so "yarn add moment" has to be run for it to work